### PR TITLE
feat: Add PERSONAL_ACCOUNT_NOT_SUPPORTED error code

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -133,6 +133,12 @@ export async function submitRun(
             if (structuredDetail.status) {
               core.debug(`Plan status: ${structuredDetail.status}`)
             }
+            if (structuredDetail.owner) {
+              core.debug(`Owner: ${structuredDetail.owner}`)
+            }
+            if (structuredDetail.owner_type) {
+              core.debug(`Owner type: ${structuredDetail.owner_type}`)
+            }
           }
 
           // Handle step list if present (works with both formats)

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,20 +45,25 @@ export type ValidateMethod =
   (typeof ValidateMethod)[keyof typeof ValidateMethod]
 
 /**
- * Error codes returned by the Product API for plan-related errors.
+ * Error codes returned by the Medusa/Product API.
+ * Includes plan-related errors and account validation errors.
  */
 export const PlanErrorCode = {
+  // Plan-related errors
   PLAN_EXPIRED: 'PLAN_EXPIRED',
   NO_PLAN_ASSIGNED: 'NO_PLAN_ASSIGNED',
   PLAN_INACTIVE: 'PLAN_INACTIVE',
+  // Account validation errors
+  PERSONAL_ACCOUNT_NOT_SUPPORTED: 'PERSONAL_ACCOUNT_NOT_SUPPORTED',
+  // Fallback
   UNKNOWN: 'UNKNOWN'
 } as const
 
 export type PlanErrorCode = (typeof PlanErrorCode)[keyof typeof PlanErrorCode]
 
 /**
- * Structured error detail returned by the Product API for 403 errors.
- * Provides actionable information about plan-related failures.
+ * Structured error detail returned by the Medusa/Product API.
+ * Provides actionable information about failures.
  */
 export interface StructuredErrorDetail {
   /** Error code identifying the type of error */
@@ -75,6 +80,10 @@ export interface StructuredErrorDetail {
   status?: string
   /** Optional step list for processing steps */
   steps?: Array<{ name: string; status: string; detail: string }>
+  /** Repository owner name (for account validation errors) */
+  owner?: string
+  /** Owner type: "User" or "Organization" (for account validation errors) */
+  owner_type?: string
 }
 
 /**


### PR DESCRIPTION
## Summary

This PR adds support for the new `PERSONAL_ACCOUNT_NOT_SUPPORTED` error code returned by Medusa when a run is attempted from a personal GitHub account instead of an organization.

## Related PR

- Hydra/Medusa: https://github.com/AppSecureAI/Hydra/pull/458

## Changes

### types.ts
- Add `PERSONAL_ACCOUNT_NOT_SUPPORTED` to the `PlanErrorCode` enum
- Add `owner` and `owner_type` fields to `StructuredErrorDetail` interface
- Update documentation comments to reflect broader error code coverage

### service.ts
- Log `owner` and `owner_type` in debug output when present in error details

## Error Display

When a user attempts to run the action from a personal account repository, they will now see a clear error message:

```
[RUN_SUBMIT] [PERSONAL_ACCOUNT_NOT_SUPPORTED] Personal GitHub accounts are not supported. Please run this action from a repository that belongs to a GitHub organization.
```

## Test plan

- [ ] Verify tests pass in CI
- [ ] Test with Hydra PR to ensure error is displayed correctly
- [ ] Verify debug logging includes owner information