### PR TITLE
ci: add mirror parity workflows and source-of-truth documentation

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -1,0 +1,42 @@
+name: Check dist
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'rollup.config.ts'
+      - 'tsconfig*.json'
+
+permissions:
+  contents: read
+
+jobs:
+  check-dist:
+    name: Check dist/
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build dist
+        run: npm run package
+
+      - name: Compare directories
+        run: |
+          if [ -n "$(git status --porcelain dist/)" ]; then
+            echo "::error::dist/ differs after build. Commit generated dist files."
+            git status --porcelain dist/
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate mirror repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .node-version
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check format
+        run: npm run format:check
+
+      - name: Lint and typecheck
+        run: npm run lint
+
+      - name: Test
+        run: npm test -- --runInBand
+
+      - name: Build dist
+        run: npm run package
+
+      - name: Verify dist is up to date
+        run: |
+          if [ -n "$(git status --porcelain dist/)" ]; then
+            echo "::error::dist/ is out of date. Rebuild dist and commit artifacts."
+            git status --porcelain dist/
+            exit 1
+          fi

--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -1,0 +1,60 @@
+name: Version parity
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to validate (optional for manual runs, e.g., v1.0.8)'
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  parity:
+    name: Tag/package version parity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Resolve tag
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            TAG="${GITHUB_REF_NAME}"
+          elif [[ -n "${{ inputs.tag || '' }}" ]]; then
+            TAG="${{ inputs.tag }}"
+          else
+            echo "::error::No tag available. For workflow_dispatch provide inputs.tag"
+            exit 1
+          fi
+
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Tag must be SemVer with v-prefix. Got: $TAG"
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Validate package.json version
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${{ steps.tag.outputs.version }}"
+          PKG_VERSION="$(node -p \"require('./package.json').version\")"
+
+          echo "Tag version: $TAG_VERSION"
+          echo "Package version: $PKG_VERSION"
+
+          if [[ "$TAG_VERSION" != "$PKG_VERSION" ]]; then
+            echo "::error::Tag ${{ steps.tag.outputs.tag }} does not match package.json version $PKG_VERSION"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ This GitHub Action provides automated security vulnerability triage,
 remediation, and validation powered by AI. Submit SARIF or JSON security scan
 results to the AppSecAI platform for intelligent analysis of your source code.
 
+## Repository Model
+
+`automation-action` is the public mirror for this action.
+
+- Canonical source-of-truth repo: `AppSecureAI/submit-run-action`
+- Public mirror repo: `AppSecureAI/automation-action`
+
+Version bumps and release source changes should be made in `submit-run-action`,
+then synchronized to this repository.
+
 ## Quick Start
 
 ```yaml


### PR DESCRIPTION
## Summary\n- add CI workflow for mirror validation (format/lint/test/build + dist verification)\n- add dist parity workflow for PR changes affecting build artifacts\n- add tag/package version parity workflow\n- document mirror/source-of-truth policy in README\n\n## Why\nMakes automation-action explicitly mirror-only and enforces downstream parity checks to prevent drift.\n\nCloses AppSecureAI/submit-run-action#309\nCloses AppSecureAI/submit-run-action#308