### PR TITLE
feat: add configurable api-url input for non-prod AppSecAI deployments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,14 @@ branding:
 
 # Define your inputs here.
 inputs:
+  api-url:
+    description:
+      The AppSecAI API base URL. Defaults to the AppSecAI production endpoint.
+      Override only when targeting a non-production AppSecAI deployment
+      (for example, an integration or pre-release environment).
+    required: false
+    default: 'https://gh.cloud.appsecai.io'
+
   file:
     description:
       The SARIF, JSON, CSV, or TSV file containing security scan results
@@ -114,7 +122,7 @@ runs:
       env:
         # Required inputs passed directly
         INPUT_FILE: ${{ inputs.file }}
-        INPUT_API_URL: https://gh.cloud.appsecai.io
+        INPUT_API_URL: ${{ inputs.api-url }}
         # Configuration from workflow environment variables (with defaults)
         # Canonical modes: individual_cc (default), group_cc, individual, regression_evidence
         # Legacy aliases (deprecated, emit warning): group_only, group_with_remediation,


### PR DESCRIPTION
## Summary
Adds an optional `api-url` input to the action so callers can target a non-production AppSecAI deployment (integration, dev, or any private deployment) without forking the action or relying on the internal `submit-run-action`.

## Why
- `submit-run-action` is private (intentionally — it's an internal-only test variant), so external customer orgs cannot use it for integration testing.
- `automation-action` is the public entry point but its API URL is hardcoded to https://gh.cloud.appsecai.io, leaving customers no way to point a workflow at integration when they want to validate prerelease guidance updates before they ship to prod.
- This blocked the integration testing workflows we wanted to add to ${'`aiden-development/appsec-test`'} for the 1.0.4_hotfix bundle PR #4753.

## What changed
- **`action.yml`**: New optional input `api-url` with default `https://gh.cloud.appsecai.io` (preserves existing behavior). Replaces the hardcoded `INPUT_API_URL: https://gh.cloud.appsecai.io` env binding with `INPUT_API_URL: \${{ inputs.api-url }}`.

## Backward compatibility
Fully backward compatible. Existing workflows that don't set `api-url` continue to hit the production endpoint exactly as before.

## Caller example (integration target)
\`\`\`yaml
- uses: AppSecureAI/automation-action@v1
  with:
    file: codeql-results/csharp.sarif
    api-url: https://gh.intg.appsecai.net
\`\`\`

## Post-merge action items
After merge, move the `v1` and `v1.1` major-version tags forward so existing `@v1` and `@v1.1.x` consumers pick up the new input. New customer-facing docs should mention `api-url` as the supported way to target non-prod (vs forking).