### PR TITLE
fix: add dependency pinning audit

### DIFF
--- a/docs/dependency-pinning.md
+++ b/docs/dependency-pinning.md
@@ -1,0 +1,32 @@
+# Dependency Pinning Policy
+
+The automation action release bundle must be reproducible from reviewed
+dependency manifests.
+
+## Current policy
+
+- `package-lock.json` is committed and is the source of truth for resolved npm
+  package versions.
+- Local and CI validation should use `npm ci`, not `npm install`.
+- Release-critical GitHub Actions must not use mutable `@main` or `@master`
+  refs.
+- `package.json` semver ranges are allowed only because `npm ci` installs from
+  the committed lockfile.
+
+## Checks
+
+Run the audit before release branches are approved:
+
+```bash
+npm run check:dependency-pinning
+```
+
+The audit fails when declared packages are missing from the lockfile, workflows
+use `npm install`, workflows use mutable action refs, or direct `pip install`
+commands are unpinned.
+
+## Version updates
+
+This policy freezes currently locked production-intended versions. Compatible
+package refreshes should be tracked as separate `1.0.6_hotfix` issues and tested
+after 1.0.6 is live.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "coverage": "npx make-coverage-badge --output-path ./badges/coverage.svg",
     "format:write": "npx prettier --write .",
     "format:check": "npx prettier --check .",
+    "check:dependency-pinning": "node scripts/check-dependency-pinning.mjs",
     "check:types": "tsc --noemit",
     "changelog": "conventional-changelog -p conventionalcommits -i CHANGELOG.md -s",
     "lint": "npx eslint && npm run check:types",

--- a/scripts/check-dependency-pinning.mjs
+++ b/scripts/check-dependency-pinning.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+
+const root = process.cwd()
+const failures = []
+
+function exists(filePath) {
+  return fs.existsSync(path.join(root, filePath))
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(path.join(root, filePath), 'utf8'))
+}
+
+function walk(dir) {
+  const abs = path.join(root, dir)
+  if (!fs.existsSync(abs)) return []
+  return fs.readdirSync(abs, { withFileTypes: true }).flatMap((entry) => {
+    const rel = path.join(dir, entry.name)
+    if (entry.isDirectory()) return walk(rel)
+    return [rel]
+  })
+}
+
+if (!exists('package.json')) {
+  failures.push('package.json is missing')
+}
+
+if (!exists('package-lock.json')) {
+  failures.push(
+    'package-lock.json is required so npm installs are reproducible'
+  )
+}
+
+if (exists('package.json') && exists('package-lock.json')) {
+  const pkg = readJson('package.json')
+  const lock = readJson('package-lock.json')
+  const declared = {
+    ...pkg.dependencies,
+    ...pkg.devDependencies,
+    ...pkg.optionalDependencies
+  }
+
+  if (!lock.packages || !lock.packages['']) {
+    failures.push(
+      'package-lock.json must be npm lockfile v2/v3 with a root package entry'
+    )
+  }
+
+  for (const name of Object.keys(declared).sort()) {
+    if (!lock.packages?.[`node_modules/${name}`]) {
+      failures.push(
+        `${name} is declared in package.json but missing from package-lock.json`
+      )
+    }
+  }
+}
+
+for (const file of walk('.github/workflows').filter((name) =>
+  /\.(ya?ml)$/.test(name)
+)) {
+  const content = fs.readFileSync(path.join(root, file), 'utf8')
+  const plainNpmInstall = content.match(/\bnpm\s+install\b(?!\s+-g)/)
+  if (plainNpmInstall) {
+    failures.push(
+      `${file} uses npm install; use npm ci for lockfile-respecting installs`
+    )
+  }
+  const mutableAction = content.match(/uses:\s*[^#\n]+@(main|master)\b/)
+  if (mutableAction) {
+    failures.push(
+      `${file} uses a mutable GitHub Action ref: ${mutableAction[0].trim()}`
+    )
+  }
+  const unpinnedPipInstall = content.match(
+    /\bpip\s+install\s+(?!.*==)(?!.*-r\b)[^\n]+/
+  )
+  if (unpinnedPipInstall) {
+    failures.push(
+      `${file} has an unpinned direct pip install: ${unpinnedPipInstall[0].trim()}`
+    )
+  }
+}
+
+if (failures.length) {
+  console.error('Dependency pinning audit failed:')
+  for (const failure of failures) console.error(`- ${failure}`)
+  process.exit(1)
+}
+
+console.log('Dependency pinning audit passed')


### PR DESCRIPTION
## Summary
- Part of AppSecureAI/Product#4991.
- Adds a lockfile/workflow dependency pinning audit for the action package.
- Keeps currently locked action dependencies unchanged for 1.0.6 readiness.

## Validation
- `npm ci`
- `npm run check:dependency-pinning`
- `npm run format:check`
- `npm run check:types`
- `git diff --check`

## Notes
- This repository currently has no `.github/workflows` directory on `main`, so the audit validates the package lockfile and will also catch mutable workflow refs if workflows are added later.
- Compatible dependency refresh candidates are intentionally deferred to AppSecureAI/automation-action#53 under `1.0.6_hotfix`.